### PR TITLE
Run workflow before merge to get latest main 🗞️

### DIFF
--- a/.github/workflows/scorecard-workflow.yaml
+++ b/.github/workflows/scorecard-workflow.yaml
@@ -2,10 +2,13 @@ name: Score Dependencies
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, closed]
 
 jobs:
   run-scorecard-on-dependencies:
+    # There is no explciit support for "merged" type, only closed, so unless we also want to run this every
+    # time a PR is closed without merging, we need to explicitly filter here
+    if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
My experiments in #45 didn't find an easier way out of the box to make
sure that a PR is tested with the latest changes out of the box, so
trying to also run the workflow on merge.

Remaining questions:
- if it failed, would it actually stop the merge? might need to
  experiment to try that out
- there's probably still a race where main could get updated while the
  check is running 🤦‍♀️ requiring the branch to be up to date
  before merging might be the only way to get this with github actions